### PR TITLE
feedbin-api(kilo-code-claude-3.7-sonnet): add implementation

### DIFF
--- a/feedbin-api/kilo-code-claude-3.7-sonnet/README.md
+++ b/feedbin-api/kilo-code-claude-3.7-sonnet/README.md
@@ -1,0 +1,208 @@
+# Feedbin API Client Implementation Plan
+
+This document outlines the plan for creating a Go client for the Feedbin API.
+
+## 1. Project Structure
+
+The project will be organized into the following Go packages and files:
+
+*   `feedbin/` (root package directory)
+    *   `client.go`: Defines the main `Client` struct and methods for interacting with the API.
+    *   `models.go`: Contains the Go structs representing the API data models (e.g., `Entry`, `Feed`, `Subscription`).
+    *   `options.go`: Defines optional parameters for API calls (e.g., for pagination, filtering).
+    *   `errors.go`: Defines custom error types for the client.
+    *   `authentication.go`: Handles authentication logic.
+    *   `endpoints.go`: Contains endpoint definitions and methods for each resource.
+
+## 2. Main `Client` Struct
+
+The primary `Client` struct will be the entry point for all API interactions.
+
+```go
+// in client.go
+package feedbin
+
+import "net/http"
+
+type Client struct {
+    httpClient    *http.Client
+    baseURL       string
+    authenticator Authenticator
+}
+
+// NewClient creates a new Feedbin API client.
+func NewClient(username, password string, options ...ClientOption) *Client {
+    // ... implementation ...
+}
+```
+
+## 3. Authentication
+
+Authentication will be handled using HTTP Basic Auth. An `Authenticator` interface will be created to allow for different authentication strategies in the future, though the initial implementation will focus on basic auth.
+
+```go
+// in authentication.go
+package feedbin
+
+import "net/http"
+
+type Authenticator interface {
+    Authenticate(req *http.Request)
+}
+
+type BasicAuth struct {
+    Username string
+    Password string
+}
+
+func (b *BasicAuth) Authenticate(req *http.Request) {
+    req.SetBasicAuth(b.Username, b.Password)
+}
+```
+
+## 4. API Methods
+
+The client will implement methods for all API resources, grouped by resource. Each resource will have its own file (e.g., `entries.go`, `feeds.go`).
+
+### Entries
+
+*   `GetEntries(opts ...RequestOption) ([]*Entry, error)`
+*   `GetFeedEntries(feedID int64, opts ...RequestOption) ([]*Entry, error)`
+*   `GetEntry(entryID int64, opts ...RequestOption) (*Entry, error)`
+
+### Feeds
+
+*   `GetFeed(feedID int64) (*Feed, error)`
+
+### Subscriptions
+
+*   `GetSubscriptions(opts ...RequestOption) ([]*Subscription, error)`
+*   `GetSubscription(subID int64) (*Subscription, error)`
+*   `CreateSubscription(feedURL string) (*Subscription, error)`
+*   `UpdateSubscription(subID int64, title string) (*Subscription, error)`
+*   `DeleteSubscription(subID int64) error`
+
+### Taggings
+
+*   `GetTaggings() ([]*Tagging, error)`
+*   `GetTagging(taggingID int64) (*Tagging, error)`
+*   `CreateTagging(feedID int64, name string) (*Tagging, error)`
+*   `DeleteTagging(taggingID int64) error`
+
+### Starred Entries
+
+*   `GetStarredEntryIDs() ([]int64, error)`
+*   `StarEntries(entryIDs []int64) error`
+*   `UnstarEntries(entryIDs []int64) error`
+
+### Unread Entries
+
+*   `GetUnreadEntryIDs() ([]int64, error)`
+*   `MarkEntriesAsRead(entryIDs []int64) error`
+*   `MarkEntriesAsUnread(entryIDs []int64) error`
+
+### Recently Read Entries
+
+*   `GetRecentlyReadEntryIDs() ([]int64, error)`
+*   `CreateRecentlyReadEntries(entryIDs []int64) error`
+
+### Saved Searches
+
+*   `GetSavedSearches() ([]*SavedSearch, error)`
+*   `GetSavedSearch(searchID int64, opts ...RequestOption) ([]int64, error)`
+*   `CreateSavedSearch(name, query string) (*SavedSearch, error)`
+*   `UpdateSavedSearch(searchID int64, name string) (*SavedSearch, error)`
+*   `DeleteSavedSearch(searchID int64) error`
+
+### And so on for all other resources...
+
+## 5. Pagination
+
+Pagination will be handled by passing `page` and `per_page` parameters in the request options. The client will not automatically handle multiple pages; it will be the responsibility of the user of the client to request subsequent pages.
+
+```go
+// in options.go
+package feedbin
+
+// ...
+
+func WithPage(page int) RequestOption {
+    // ...
+}
+
+func WithPerPage(perPage int) RequestOption {
+    // ...
+}
+```
+
+## 6. Error Handling
+
+A custom error struct will be used to provide more context on API errors.
+
+```go
+// in errors.go
+package feedbin
+
+import "fmt"
+
+type APIError struct {
+    StatusCode int
+    Body       string
+    Message    string
+}
+
+func (e *APIError) Error() string {
+    return fmt.Sprintf("API Error: %d %s - %s", e.StatusCode, e.Message, e.Body)
+}
+```
+
+The client will check the HTTP status code of each response and return an `*APIError` if the request was not successful.
+
+## 7. Data Models
+
+Go structs will be defined in `models.go` to represent the JSON data structures returned by the API.
+
+```go
+// in models.go
+package feedbin
+
+import "time"
+
+type Entry struct {
+    ID                  int64      `json:"id"`
+    FeedID              int64      `json:"feed_id"`
+    Title               *string    `json:"title"`
+    URL                 string     `json:"url"`
+    Author              *string    `json:"author"`
+    Content             *string    `json:"content"`
+    Summary             string     `json:"summary"`
+    Published           time.Time  `json:"published"`
+    CreatedAt           time.Time  `json:"created_at"`
+    ExtractedContentURL string     `json:"extracted_content_url"`
+    // ... other fields
+}
+
+type Feed struct {
+    ID      int64  `json:"id"`
+    Title   string `json:"title"`
+    FeedURL string `json:"feed_url"`
+    SiteURL string `json:"site_url"`
+}
+
+// ... and so on for all other models
+```
+
+## 8. Content Extraction
+
+The client will provide a helper function to generate the signed URL for the content extraction service.
+
+```go
+// in client.go
+package feedbin
+
+func (c *Client) GetContentExtractorURL(url string) (string, error) {
+    // ... implementation to generate signed URL ...
+}
+```
+
+This function will require the user to provide their content extraction username and secret.

--- a/feedbin-api/kilo-code-claude-3.7-sonnet/feedbin/authentication.go
+++ b/feedbin-api/kilo-code-claude-3.7-sonnet/feedbin/authentication.go
@@ -1,0 +1,16 @@
+package feedbin
+
+import "net/http"
+
+type Authenticator interface {
+	Authenticate(req *http.Request)
+}
+
+type BasicAuth struct {
+	Username string
+	Password string
+}
+
+func (b *BasicAuth) Authenticate(req *http.Request) {
+	req.SetBasicAuth(b.Username, b.Password)
+}

--- a/feedbin-api/kilo-code-claude-3.7-sonnet/feedbin/client.go
+++ b/feedbin-api/kilo-code-claude-3.7-sonnet/feedbin/client.go
@@ -1,0 +1,137 @@
+package feedbin
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	defaultBaseURL = "https://api.feedbin.com/v2/"
+	defaultTimeout = 10 * time.Second
+)
+
+type Client struct {
+	httpClient    *http.Client
+	baseURL       string
+	authenticator Authenticator
+	secret        []byte
+}
+
+type ClientOption func(*Client)
+
+func NewClient(username, password string, options ...ClientOption) *Client {
+	c := &Client{
+		httpClient: &http.Client{
+			Timeout: defaultTimeout,
+		},
+		baseURL:       defaultBaseURL,
+		authenticator: &BasicAuth{Username: username, Password: password},
+	}
+
+	for _, opt := range options {
+		opt(c)
+	}
+
+	return c
+}
+
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(c *Client) {
+		c.httpClient = httpClient
+	}
+}
+
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) {
+		c.baseURL = baseURL
+	}
+}
+
+func WithContentExtractorSecret(secret string) ClientOption {
+	return func(c *Client) {
+		c.secret = []byte(secret)
+	}
+}
+
+func (c *Client) GetContentExtractorURL(pageURL string) (string, error) {
+	if c.secret == nil {
+		return "", fmt.Errorf("content extractor secret not configured")
+	}
+	mac := hmac.New(sha1.New, c.secret)
+	mac.Write([]byte(pageURL))
+	signature := hex.EncodeToString(mac.Sum(nil))
+	encodedURL := base64.StdEncoding.EncodeToString([]byte(pageURL))
+	return fmt.Sprintf("/parser/feedbin/%s?base64_url=%s", signature, encodedURL), nil
+}
+
+func (c *Client) newRequest(method, path string, body interface{}, opts ...RequestOption) (*http.Request, error) {
+	u, err := url.Parse(c.baseURL + path)
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	for _, opt := range opts {
+		opt(q)
+	}
+	u.RawQuery = q.Encode()
+
+	var buf io.ReadWriter
+	if body != nil {
+		buf = new(bytes.Buffer)
+		err := json.NewEncoder(buf).Encode(body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest(method, u.String(), buf)
+	if err != nil {
+		return nil, err
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	c.authenticator.Authenticate(req)
+
+	return req, nil
+}
+
+func (c *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		return resp, &APIError{
+			StatusCode: resp.StatusCode,
+			Body:       string(bodyBytes),
+			Message:    http.StatusText(resp.StatusCode),
+		}
+	}
+
+	if v != nil {
+		if w, ok := v.(io.Writer); ok {
+			io.Copy(w, resp.Body)
+		} else {
+			err = json.NewDecoder(resp.Body).Decode(v)
+		}
+	}
+
+	return resp, err
+}

--- a/feedbin-api/kilo-code-claude-3.7-sonnet/feedbin/endpoints.go
+++ b/feedbin-api/kilo-code-claude-3.7-sonnet/feedbin/endpoints.go
@@ -1,0 +1,512 @@
+package feedbin
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+)
+
+// Entries
+
+func (c *Client) GetEntries(opts ...RequestOption) ([]*Entry, error) {
+	req, err := c.newRequest("GET", "entries.json", nil, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var entries []*Entry
+	_, err = c.do(req, &entries)
+	return entries, err
+}
+
+func (c *Client) GetFeedEntries(feedID int64, opts ...RequestOption) ([]*Entry, error) {
+	path := fmt.Sprintf("feeds/%d/entries.json", feedID)
+	req, err := c.newRequest("GET", path, nil, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var entries []*Entry
+	_, err = c.do(req, &entries)
+	return entries, err
+}
+
+func (c *Client) GetEntry(entryID int64, opts ...RequestOption) (*Entry, error) {
+	path := fmt.Sprintf("entries/%d.json", entryID)
+	req, err := c.newRequest("GET", path, nil, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var entry Entry
+	_, err = c.do(req, &entry)
+	return &entry, err
+}
+
+// Feeds
+
+func (c *Client) GetFeed(feedID int64) (*Feed, error) {
+	path := fmt.Sprintf("feeds/%d.json", feedID)
+	req, err := c.newRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var feed Feed
+	_, err = c.do(req, &feed)
+	return &feed, err
+}
+
+// Subscriptions
+
+func (c *Client) GetSubscriptions(opts ...RequestOption) ([]*Subscription, error) {
+	req, err := c.newRequest("GET", "subscriptions.json", nil, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var subs []*Subscription
+	_, err = c.do(req, &subs)
+	return subs, err
+}
+
+func (c *Client) GetSubscription(subID int64) (*Subscription, error) {
+	path := fmt.Sprintf("subscriptions/%d.json", subID)
+	req, err := c.newRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var sub Subscription
+	_, err = c.do(req, &sub)
+	return &sub, err
+}
+
+func (c *Client) CreateSubscription(feedURL string) (*Subscription, error) {
+	body := map[string]string{"feed_url": feedURL}
+	req, err := c.newRequest("POST", "subscriptions.json", body)
+	if err != nil {
+		return nil, err
+	}
+	var sub Subscription
+	_, err = c.do(req, &sub)
+	return &sub, err
+}
+
+func (c *Client) UpdateSubscription(subID int64, title string) (*Subscription, error) {
+	path := fmt.Sprintf("subscriptions/%d.json", subID)
+	body := map[string]string{"title": title}
+	req, err := c.newRequest("PATCH", path, body)
+	if err != nil {
+		return nil, err
+	}
+	var sub Subscription
+	_, err = c.do(req, &sub)
+	return &sub, err
+}
+
+func (c *Client) DeleteSubscription(subID int64) error {
+	path := fmt.Sprintf("subscriptions/%d.json", subID)
+	req, err := c.newRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+	_, err = c.do(req, nil)
+	return err
+}
+
+// Taggings
+
+func (c *Client) GetTaggings() ([]*Tagging, error) {
+	req, err := c.newRequest("GET", "taggings.json", nil)
+	if err != nil {
+		return nil, err
+	}
+	var taggings []*Tagging
+	_, err = c.do(req, &taggings)
+	return taggings, err
+}
+
+func (c *Client) GetTagging(taggingID int64) (*Tagging, error) {
+	path := fmt.Sprintf("taggings/%d.json", taggingID)
+	req, err := c.newRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var tagging Tagging
+	_, err = c.do(req, &tagging)
+	return &tagging, err
+}
+
+func (c *Client) CreateTagging(feedID int64, name string) (*Tagging, error) {
+	body := map[string]string{
+		"feed_id": strconv.FormatInt(feedID, 10),
+		"name":    name,
+	}
+	req, err := c.newRequest("POST", "taggings.json", body)
+	if err != nil {
+		return nil, err
+	}
+	var tagging Tagging
+	_, err = c.do(req, &tagging)
+	return &tagging, err
+}
+
+func (c *Client) DeleteTagging(taggingID int64) error {
+	path := fmt.Sprintf("taggings/%d.json", taggingID)
+	req, err := c.newRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+	_, err = c.do(req, nil)
+	return err
+}
+
+// Starred Entries
+
+func (c *Client) GetStarredEntryIDs() ([]int64, error) {
+	req, err := c.newRequest("GET", "starred_entries.json", nil)
+	if err != nil {
+		return nil, err
+	}
+	var ids []int64
+	_, err = c.do(req, &ids)
+	return ids, err
+}
+
+func (c *Client) StarEntries(entryIDs []int64) ([]int64, error) {
+	body := map[string][]int64{"starred_entries": entryIDs}
+	req, err := c.newRequest("POST", "starred_entries.json", body)
+	if err != nil {
+		return nil, err
+	}
+	var ids []int64
+	_, err = c.do(req, &ids)
+	return ids, err
+}
+
+func (c *Client) UnstarEntries(entryIDs []int64) ([]int64, error) {
+	body := map[string][]int64{"starred_entries": entryIDs}
+	req, err := c.newRequest("DELETE", "starred_entries.json", body)
+	if err != nil {
+		return nil, err
+	}
+	var ids []int64
+	_, err = c.do(req, &ids)
+	return ids, err
+}
+
+// Unread Entries
+
+func (c *Client) GetUnreadEntryIDs() ([]int64, error) {
+	req, err := c.newRequest("GET", "unread_entries.json", nil)
+	if err != nil {
+		return nil, err
+	}
+	var ids []int64
+	_, err = c.do(req, &ids)
+	return ids, err
+}
+
+func (c *Client) MarkEntriesAsUnread(entryIDs []int64) ([]int64, error) {
+	body := map[string][]int64{"unread_entries": entryIDs}
+	req, err := c.newRequest("POST", "unread_entries.json", body)
+	if err != nil {
+		return nil, err
+	}
+	var ids []int64
+	_, err = c.do(req, &ids)
+	return ids, err
+}
+
+func (c *Client) MarkEntriesAsRead(entryIDs []int64) ([]int64, error) {
+	body := map[string][]int64{"unread_entries": entryIDs}
+	req, err := c.newRequest("DELETE", "unread_entries.json", body)
+	if err != nil {
+		return nil, err
+	}
+	var ids []int64
+	_, err = c.do(req, &ids)
+	return ids, err
+}
+
+// Recently Read Entries
+
+func (c *Client) GetRecentlyReadEntryIDs() ([]int64, error) {
+	req, err := c.newRequest("GET", "recently_read_entries.json", nil)
+	if err != nil {
+		return nil, err
+	}
+	var ids []int64
+	_, err = c.do(req, &ids)
+	return ids, err
+}
+
+func (c *Client) CreateRecentlyReadEntries(entryIDs []int64) ([]int64, error) {
+	body := map[string][]int64{"recently_read_entries": entryIDs}
+	req, err := c.newRequest("POST", "recently_read_entries.json", body)
+	if err != nil {
+		return nil, err
+	}
+	var ids []int64
+	_, err = c.do(req, &ids)
+	return ids, err
+}
+
+// Saved Searches
+
+func (c *Client) GetSavedSearches() ([]*SavedSearch, error) {
+	req, err := c.newRequest("GET", "saved_searches.json", nil)
+	if err != nil {
+		return nil, err
+	}
+	var searches []*SavedSearch
+	_, err = c.do(req, &searches)
+	return searches, err
+}
+
+func (c *Client) GetSavedSearch(searchID int64, opts ...RequestOption) ([]int64, error) {
+	path := fmt.Sprintf("saved_searches/%d.json", searchID)
+	req, err := c.newRequest("GET", path, nil, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var ids []int64
+	_, err = c.do(req, &ids)
+	return ids, err
+}
+
+func (c *Client) CreateSavedSearch(name, query string) (*SavedSearch, error) {
+	body := map[string]string{"name": name, "query": query}
+	req, err := c.newRequest("POST", "saved_searches.json", body)
+	if err != nil {
+		return nil, err
+	}
+	var search SavedSearch
+	_, err = c.do(req, &search)
+	return &search, err
+}
+
+func (c *Client) UpdateSavedSearch(searchID int64, name string) (*SavedSearch, error) {
+	path := fmt.Sprintf("saved_searches/%d.json", searchID)
+	body := map[string]string{"name": name}
+	req, err := c.newRequest("PATCH", path, body)
+	if err != nil {
+		return nil, err
+	}
+	var search SavedSearch
+	_, err = c.do(req, &search)
+	return &search, err
+}
+
+func (c *Client) DeleteSavedSearch(searchID int64) error {
+	path := fmt.Sprintf("saved_searches/%d.json", searchID)
+	req, err := c.newRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+	_, err = c.do(req, nil)
+	return err
+}
+// Authentication
+
+func (c *Client) Authenticate() (bool, error) {
+	req, err := c.newRequest("GET", "authentication.json", nil)
+	if err != nil {
+		return false, err
+	}
+	_, err = c.do(req, nil)
+	if err != nil {
+		if apiErr, ok := err.(*APIError); ok && apiErr.StatusCode == 401 {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+// Icons
+
+func (c *Client) GetIcons() ([]*Icon, error) {
+	req, err := c.newRequest("GET", "icons.json", nil)
+	if err != nil {
+		return nil, err
+	}
+	var icons []*Icon
+	_, err = c.do(req, &icons)
+	return icons, err
+}
+
+// Imports
+
+func (c *Client) CreateImport(opml io.Reader) (*Import, error) {
+	req, err := c.newRequest("POST", "imports.json", opml)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "text/xml")
+	var imp Import
+	_, err = c.do(req, &imp)
+	return &imp, err
+}
+
+func (c *Client) GetImports() ([]*Import, error) {
+	req, err := c.newRequest("GET", "imports.json", nil)
+	if err != nil {
+		return nil, err
+	}
+	var imports []*Import
+	_, err = c.do(req, &imports)
+	return imports, err
+}
+
+func (c *Client) GetImport(importID int64) (*Import, error) {
+	path := fmt.Sprintf("imports/%d.json", importID)
+	req, err := c.newRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var imp Import
+	_, err = c.do(req, &imp)
+	return &imp, err
+}
+// Pages
+
+func (c *Client) CreatePage(page *Page) (*Entry, error) {
+	req, err := c.newRequest("POST", "pages.json", page)
+	if err != nil {
+		return nil, err
+	}
+	var entry Entry
+	_, err = c.do(req, &entry)
+	return &entry, err
+}
+
+func (c *Client) GetPageContent(pageID int64) (string, error) {
+	path := fmt.Sprintf("pages/%d/content.json", pageID)
+	req, err := c.newRequest("GET", path, nil)
+	if err != nil {
+		return "", err
+	}
+	var pageContent PageContent
+	_, err = c.do(req, &pageContent)
+	return pageContent.Content, err
+}
+// Tags
+
+func (c *Client) RenameTag(oldName, newName string) ([]*Tagging, error) {
+	body := map[string]string{"old_name": oldName, "new_name": newName}
+	req, err := c.newRequest("POST", "tags.json", body)
+	if err != nil {
+		return nil, err
+	}
+	var taggings []*Tagging
+	_, err = c.do(req, &taggings)
+	return taggings, err
+}
+
+func (c *Client) DeleteTag(name string) ([]*Tagging, error) {
+	body := map[string]string{"name": name}
+	req, err := c.newRequest("DELETE", "tags.json", body)
+	if err != nil {
+		return nil, err
+	}
+	var taggings []*Tagging
+	_, err = c.do(req, &taggings)
+	return taggings, err
+}
+// Updated Entries
+
+func (c *Client) GetUpdatedEntryIDs(opts ...RequestOption) ([]int64, error) {
+	req, err := c.newRequest("GET", "updated_entries.json", nil, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var ids []int64
+	_, err = c.do(req, &ids)
+	return ids, err
+}
+
+func (c *Client) DeleteUpdatedEntries(entryIDs []int64) ([]int64, error) {
+	body := map[string][]int64{"updated_entries": entryIDs}
+	req, err := c.newRequest("DELETE", "updated_entries.json", body)
+	if err != nil {
+		return nil, err
+	}
+	var ids []int64
+	_, err = c.do(req, &ids)
+	return ids, err
+}
+
+// Twitter Accounts
+
+func (c *Client) GetTwitterAccounts() ([]*TwitterAccount, error) {
+	req, err := c.newRequest("GET", "twitter_accounts.json", nil)
+	if err != nil {
+		return nil, err
+	}
+	var accounts []*TwitterAccount
+	_, err = c.do(req, &accounts)
+	return accounts, err
+}
+
+func (c *Client) GetTwitterAccount(accountID int64) (*TwitterAccount, error) {
+	path := fmt.Sprintf("twitter_accounts/%d.json", accountID)
+	req, err := c.newRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var account TwitterAccount
+	_, err = c.do(req, &account)
+	return &account, err
+}
+
+// Twitter Tweets
+
+func (c *Client) GetTwitterAccountTweets(accountID int64, opts ...RequestOption) ([]*Tweet, error) {
+	path := fmt.Sprintf("twitter_accounts/%d/tweets.json", accountID)
+	req, err := c.newRequest("GET", path, nil, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var tweets []*Tweet
+	_, err = c.do(req, &tweets)
+	return tweets, err
+}
+
+func (c *Client) GetTwitterTweet(tweetID int64) (*Tweet, error) {
+	path := fmt.Sprintf("twitter_tweets/%d.json", tweetID)
+	req, err := c.newRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var tweet Tweet
+	_, err = c.do(req, &tweet)
+	return &tweet, err
+}
+func (c *Client) UpdateSubscriptionAlt(subID int64, title string) (*Subscription, error) {
+	path := fmt.Sprintf("subscriptions/%d/update.json", subID)
+	body := map[string]string{"title": title}
+	req, err := c.newRequest("POST", path, body)
+	if err != nil {
+		return nil, err
+	}
+	var sub Subscription
+	_, err = c.do(req, &sub)
+	return &sub, err
+}
+
+func (c *Client) DeleteTagAlt(name string) ([]*Tagging, error) {
+	body := map[string]string{"name": name}
+	req, err := c.newRequest("POST", "tags/delete.json", body)
+	if err != nil {
+		return nil, err
+	}
+	var taggings []*Tagging
+	_, err = c.do(req, &taggings)
+	return taggings, err
+}
+
+func (c *Client) DeleteUpdatedEntriesAlt(entryIDs []int64) ([]int64, error) {
+	body := map[string][]int64{"updated_entries": entryIDs}
+	req, err := c.newRequest("POST", "updated_entries/delete.json", body)
+	if err != nil {
+		return nil, err
+	}
+	var ids []int64
+	_, err = c.do(req, &ids)
+	return ids, err
+}

--- a/feedbin-api/kilo-code-claude-3.7-sonnet/feedbin/errors.go
+++ b/feedbin-api/kilo-code-claude-3.7-sonnet/feedbin/errors.go
@@ -1,0 +1,13 @@
+package feedbin
+
+import "fmt"
+
+type APIError struct {
+	StatusCode int
+	Body       string
+	Message    string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API Error: %d %s - %s", e.StatusCode, e.Message, e.Body)
+}

--- a/feedbin-api/kilo-code-claude-3.7-sonnet/feedbin/models.go
+++ b/feedbin-api/kilo-code-claude-3.7-sonnet/feedbin/models.go
@@ -1,0 +1,121 @@
+package feedbin
+
+import "time"
+
+type Entry struct {
+	ID                  int64               `json:"id"`
+	FeedID              int64               `json:"feed_id"`
+	Title               *string             `json:"title"`
+	URL                 string              `json:"url"`
+	Author              *string             `json:"author"`
+	Content             *string             `json:"content"`
+	Summary             string              `json:"summary"`
+	Published           time.Time           `json:"published"`
+	CreatedAt           time.Time           `json:"created_at"`
+	ExtractedContentURL string              `json:"extracted_content_url"`
+	Original            *Entry              `json:"original,omitempty"`
+	Images              *Images             `json:"images,omitempty"`
+	Enclosure           *Enclosure          `json:"enclosure,omitempty"`
+	TwitterID           *int64              `json:"twitter_id,omitempty"`
+	TwitterThreadIDs    []int64             `json:"twitter_thread_ids,omitempty"`
+	ExtractedArticles   []*ExtractedArticle `json:"extracted_articles,omitempty"`
+	JSONFeed            *map[string]any     `json:"json_feed,omitempty"`
+}
+
+type Feed struct {
+	ID      int64  `json:"id"`
+	Title   string `json:"title"`
+	FeedURL string `json:"feed_url"`
+	SiteURL string `json:"site_url"`
+}
+
+type Subscription struct {
+	ID        int64           `json:"id"`
+	CreatedAt time.Time       `json:"created_at"`
+	FeedID    int64           `json:"feed_id"`
+	Title     string          `json:"title"`
+	FeedURL   string          `json:"feed_url"`
+	SiteURL   string          `json:"site_url"`
+	JSONFeed  *map[string]any `json:"json_feed,omitempty"`
+}
+
+type Tagging struct {
+	ID     int64  `json:"id"`
+	FeedID int64  `json:"feed_id"`
+	Name   string `json:"name"`
+}
+
+type SavedSearch struct {
+	ID    int64  `json:"id"`
+	Name  string `json:"name"`
+	Query string `json:"query"`
+}
+
+type Images struct {
+	OriginalURL string    `json:"original_url"`
+	Size1       ImageSize `json:"size_1"`
+}
+
+type ImageSize struct {
+	CDNURL string `json:"cdn_url"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+}
+
+type Enclosure struct {
+	URL      string `json:"enclosure_url"`
+	Type     string `json:"enclosure_type"`
+	Length   string `json:"enclosure_length"`
+	Duration string `json:"itunes_duration"`
+	Image    string `json:"itunes_image"`
+}
+
+type ExtractedArticle struct {
+	URL     string  `json:"url"`
+	Title   string  `json:"title"`
+	Host    string  `json:"host"`
+	Author  *string `json:"author"`
+	Content string  `json:"content"`
+}
+
+type Icon struct {
+	Host string `json:"host"`
+	URL  string `json:"url"`
+}
+
+type Import struct {
+	ID          int64         `json:"id"`
+	Complete    bool          `json:"complete"`
+	CreatedAt   time.Time     `json:"created_at"`
+	ImportItems []*ImportItem `json:"import_items,omitempty"`
+}
+
+type ImportItem struct {
+	Title   string `json:"title"`
+	FeedURL string `json:"feed_url"`
+	Status  string `json:"status"`
+}
+
+type Page struct {
+	URL   string  `json:"url"`
+	Title *string `json:"title,omitempty"`
+}
+
+type PageContent struct {
+	Content string `json:"content"`
+}
+
+type TwitterAccount struct {
+	ID              int64     `json:"id"`
+	CreatedAt       time.Time `json:"created_at"`
+	ScreenName      string    `json:"screen_name"`
+	ProfileImageURL string    `json:"profile_image_url"`
+}
+
+type Tweet struct {
+	ID         int64     `json:"id"`
+	Text       string    `json:"text"`
+	CreatedAt  time.Time `json:"created_at"`
+	ScreenName string    `json:"screen_name"`
+	TweetID    int64     `json:"tweet_id"`
+}

--- a/feedbin-api/kilo-code-claude-3.7-sonnet/feedbin/options.go
+++ b/feedbin-api/kilo-code-claude-3.7-sonnet/feedbin/options.go
@@ -1,0 +1,20 @@
+package feedbin
+
+import (
+	"net/url"
+	"strconv"
+)
+
+type RequestOption func(v url.Values)
+
+func WithPage(page int) RequestOption {
+	return func(v url.Values) {
+		v.Set("page", strconv.Itoa(page))
+	}
+}
+
+func WithPerPage(perPage int) RequestOption {
+	return func(v url.Values) {
+		v.Set("per_page", strconv.Itoa(perPage))
+	}
+}

--- a/feedbin-api/kilo-code-claude-3.7-sonnet/go.mod
+++ b/feedbin-api/kilo-code-claude-3.7-sonnet/go.mod
@@ -1,0 +1,3 @@
+module feedbin.com/feedbin-api
+
+go 1.24.3


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

New Feedbin API client implementation in Go featuring comprehensive API coverage, authentication handling, and content extraction capabilities.

- Critical: Invalid module path 'feedbin.com/feedbin-api' in `go.mod` and incorrect Go version (1.24.3) specification
- Concern: Duplicate alternative implementations in `feedbin/endpoints.go` (UpdateSubscriptionAlt, DeleteTagAlt) causing potential maintenance issues
- Issue: Twitter-related endpoints implemented despite being deprecated by Feedbin
- Improvement Needed: `feedbin/errors.go` lacks constructor methods and helper functions for error type checking
- Well-Structured: Clean interface-based design in `feedbin/authentication.go` allows for future auth method extensions



<!-- /greptile_comment -->